### PR TITLE
sys/cpuset.h must be included after sys/param.h (FreeBSD)

### DIFF
--- a/highwayhash/os_specific.cc
+++ b/highwayhash/os_specific.cc
@@ -53,8 +53,8 @@
 
 #ifdef __FreeBSD__
 #define OS_FREEBSD 1
-#include <sys/cpuset.h>
 #include <sys/param.h>
+#include <sys/cpuset.h>			/* must come after sys/param.h */
 #include <unistd.h>
 #else
 #define OS_FREEBSD 0


### PR DESCRIPTION
According to the cpuset(2) man page, sys/param.h must be included
before sys/cpuset.h. This was fixed in May of 2020 (bac1f23) and
undone in August of 2020 (9490b14).

Fix the order again and add a comment while we're here.